### PR TITLE
Run ROS Pub/Sub in Docker Containers

### DIFF
--- a/ISR_WK3/scripts/docker-compose.yml
+++ b/ISR_WK3/scripts/docker-compose.yml
@@ -4,25 +4,25 @@ services:
     command: roscore
     ports:
       - "11311:11311"
-  
+
   publisher:
     image: ros:noetic-ros-core
-    depends_on:
-      - rosmaster
     environment:
       - ROS_MASTER_URI=http://rosmaster:11311
       - ROS_HOSTNAME=publisher
     volumes:
       - ./publisher.py:/app/publisher.py
     command: bash -c "source /opt/ros/noetic/setup.bash && python3 /app/publisher.py"
-  
-  subscriber:
-    image: ros:noetic-ros-core
     depends_on:
       - rosmaster
+
+  subscriber:
+    image: ros:noetic-ros-core
     environment:
       - ROS_MASTER_URI=http://rosmaster:11311
       - ROS_HOSTNAME=subscriber
     volumes:
       - ./subscriber.py:/app/subscriber.py
     command: bash -c "source /opt/ros/noetic/setup.bash && python3 /app/subscriber.py"
+    depends_on:
+      - publisher

--- a/ISR_WK3/scripts/docker-compose.yml
+++ b/ISR_WK3/scripts/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  rosmaster:
+    image: ros:noetic-ros-core
+    command: roscore
+    ports:
+      - "11311:11311"
+  
+  publisher:
+    image: ros:noetic-ros-core
+    depends_on:
+      - rosmaster
+    environment:
+      - ROS_MASTER_URI=http://rosmaster:11311
+      - ROS_HOSTNAME=publisher
+    volumes:
+      - ./publisher.py:/app/publisher.py
+    command: bash -c "source /opt/ros/noetic/setup.bash && python3 /app/publisher.py"
+  
+  subscriber:
+    image: ros:noetic-ros-core
+    depends_on:
+      - rosmaster
+    environment:
+      - ROS_MASTER_URI=http://rosmaster:11311
+      - ROS_HOSTNAME=subscriber
+    volumes:
+      - ./subscriber.py:/app/subscriber.py
+    command: bash -c "source /opt/ros/noetic/setup.bash && python3 /app/subscriber.py"

--- a/ISR_WK3/scripts/subscriber.py
+++ b/ISR_WK3/scripts/subscriber.py
@@ -7,7 +7,7 @@ def process_subscriber_msg(data):
 
 def create_subscriber():
   rospy.init_node('subscriber_node')
-  rospy.Subscriber("publisher_1", String, callback)
+  rospy.Subscriber("publisher_1", String, process_subscriber_msg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What Changed
- Implement ROS Pub/Sub using docker containers

# How to Test
- Pull branch locally
- `cd` into `ISR_WK3/scripts` folder
- RUN `docker compose up`
- Should the see the following steps:

---

### Step 1: Pulling image and running containers
<img width="711" alt="Screenshot 2025-02-13 at 12 25 44" src="https://github.com/user-attachments/assets/dc8243f2-3c21-410b-9e4b-747692fe8171" />

### Step 2: Running Publisher
<img width="711" alt="Screenshot 2025-02-13 at 12 26 18" src="https://github.com/user-attachments/assets/6a28c472-1900-4d02-976e-1b82e2303a1b" />

### Step 3: Running Subscriber
<img width="711" alt="Screenshot 2025-02-13 at 12 26 30" src="https://github.com/user-attachments/assets/dbb94303-e0a6-41a6-9a21-990194507624" />

---

## How to Kill the Running Containers
- Open a new terminal window in the same directory as`ISR_WK2/scripts` 
- RUN `docker-compose down -v`